### PR TITLE
feat: Claim Referral UCAN, remove SSX endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@web3-storage/w3up-client": "^4.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
-    "express": "^4.18.1"
+    "express": "^4.18.1",
+    "multiformats": "^11.0.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,15 @@
 import express, { Express, Request, Response } from "express";
 import dotenv from "dotenv";
 import cors from "cors";
-import { SSXServer, SSXExpressMiddleware } from "@spruceid/ssx-server";
+import { SiweMessage } from "siwe";
 import { create } from "@web3-storage/w3up-client";
 import { StoreConf } from "@web3-storage/access";
 import * as UCANDID from "@ipld/dag-ucan/did";
 import * as UCAN from "@ipld/dag-ucan";
 import { CarWriter } from "@ipld/car";
 import { Readable } from "stream";
+import * as Block from "multiformats/block";
+import { sha256 as hasher } from "multiformats/hashes/sha2";
 
 dotenv.config();
 
@@ -15,25 +17,6 @@ const app: Express = express();
 const port = process.env.PORT || 3001;
 
 app.set("trust proxy", process.env.TRUST_PROXY ?? "loopback");
-
-const ssx = new SSXServer({
-  signingKey: process.env.SSX_SIGNING_KEY,
-  providers: {
-    metrics: {
-      service: "ssx",
-      apiKey: process.env.SSX_API_TOKEN ?? "",
-    },
-    sessionConfig: {
-      sessionOptions: {
-        cookie: {
-          domain: process.env.SESSION_DOMAIN,
-          sameSite: "none",
-          secure: true,
-        },
-      },
-    },
-  },
-});
 
 const store = new StoreConf({
   profile: process.env.W3_STORE_NAME ?? "cadastre-ssx-server",
@@ -50,9 +33,10 @@ app.use(
   })
 );
 
-app.use(SSXExpressMiddleware(ssx));
+app.use(express.json());
 
-app.post("/delegations", async (req: Request, res: Response) => {
+// Get a delegation for W3up storage
+app.post("/delegations/storage", async (req: Request, res: Response) => {
   if (!req.body) {
     res.status(422).json({ message: "Expected body." });
     return;
@@ -67,38 +51,68 @@ app.post("/delegations", async (req: Request, res: Response) => {
     res.status(422).json({ message: "Expected the field `siwe` in the body." });
     return;
   }
-  let ssxLoginResponse;
-  try {
-    ssxLoginResponse = await ssx.login(
-      req.body.siwe,
-      req.body.signature,
-      req.body.daoLogin,
-      req.body.resolveEns,
-      req.session.nonce,
-      req.body.resolveLens
-    );
-  } catch (error: any) {
-    return res.status(500).json({ message: error.message });
-  }
-  const { success, error, session } = ssxLoginResponse;
-  if (!success) {
-    let message = error.type;
-    if (error.expected && error.received) {
-      message += ` Expected: ${error.expected}. Received: ${error.received}`;
-    }
-    return res.status(400).json({ message });
-  }
 
-  if (!req.body.aud) {
-    return res
-      .status(400)
-      .json({ success: false, message: "Missing required 'aud' from body" });
+  const { siwe, signature } = req.body;
+  const siweMessage = new SiweMessage(siwe);
+
+  try {
+    await siweMessage.verify({ signature: signature });
+  } catch (error: any) {
+    return res.status(401).json({ message: error.message });
   }
 
   const w3upClient = await w3upClientP;
-  const didAud = UCANDID.parse(req.body.aud);
+  const didAud = UCANDID.parse(siweMessage.uri);
+
+  // Issue UCAN for w3up
+  const w3UpDelegation = await w3upClient.createDelegation(
+    didAud,
+    ["upload/add", "store/add"],
+    { expiration: Math.floor(Date.now() / 1000) + 86400 } // +24 hours
+  );
+
+  const { writer, out } = CarWriter.create([w3UpDelegation.root.cid as any]);
+  // @ts-ignore
+  for (const block of delegation.export()) {
+    writer.put(block);
+  }
+
+  writer.close();
+
+  res.setHeader("Content-Type", "application/vnd.ipld.car");
+  Readable.from(out).pipe(res);
+});
+
+// Get a delegation for Claim Referral
+app.post("/delegations/claim-referral", async (req: Request, res: Response) => {
+  if (!req.body) {
+    res.status(422).json({ message: "Expected body." });
+    return;
+  }
+  if (!req.body.signature) {
+    res
+      .status(422)
+      .json({ message: "Expected the field `signature` in body." });
+    return;
+  }
+  if (!req.body.siwe) {
+    res.status(422).json({ message: "Expected the field `siwe` in the body." });
+    return;
+  }
+
+  const { siwe, signature } = req.body;
+  const siweMessage = new SiweMessage(siwe);
+
+  try {
+    await siweMessage.verify({ signature: signature });
+  } catch (error: any) {
+    return res.status(401).json({ message: error.message });
+  }
+
+  const w3upClient = await w3upClientP;
+  const didAud = UCANDID.parse(siweMessage.uri);
   const didPkh = UCANDID.parse(
-    `did:pkh:eip155:${session.siwe.chainId}:${session.siwe.address}`
+    `did:pkh:eip155:${siweMessage.chainId}:${siweMessage.address}`
   );
 
   // Issue UCAN for claim referral
@@ -113,21 +127,18 @@ app.post("/delegations", async (req: Request, res: Response) => {
       },
     ],
   });
+  const claimReferralDelegationBlock = await Block.encode({
+    value: claimReferralDelegation,
+    codec: UCAN,
+    hasher,
+  });
 
-  console.log(UCAN.format(claimReferralDelegation));
+  const { writer, out } = CarWriter.create([claimReferralDelegationBlock.cid]);
 
-  // Issue UCAN for w3up
-  const w3UpDelegation = await w3upClient.createDelegation(
-    didAud,
-    ["upload/add", "store/add"],
-    { expiration: Math.floor(Date.now() / 1000) + 86400 } // +24 hours
-  );
-
-  const { writer, out } = CarWriter.create([w3UpDelegation.root.cid as any]);
-  // @ts-ignore
-  for (const block of delegation.export()) {
-    writer.put(block);
-  }
+  writer.put({
+    cid: claimReferralDelegationBlock.cid,
+    bytes: claimReferralDelegationBlock.bytes,
+  });
 
   writer.close();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,9 +437,9 @@
   integrity sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==
 
 "@noble/hashes@^1.1.2":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.5.tgz#1a0377f3b9020efe2fae03290bd2a12140c95c11"
-  integrity sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
+  integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -504,30 +504,30 @@
     uri-js "^4.4.1"
     valid-url "^1.0.9"
 
-"@spruceid/ssx-core@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@spruceid/ssx-core/-/ssx-core-1.1.1.tgz#1c08b7d69f4085d79c2d98ace5f4159b3fc65946"
-  integrity sha512-n1XlG/VLe95J8ToV/GPGG7cidnyqR6s5cafhZ/w6J3ZCXh4qLKoJ3HCJ8TtZxNWZRNM/L8Prf1zS58GSdK7HTA==
+"@spruceid/ssx-core@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@spruceid/ssx-core/-/ssx-core-1.2.0.tgz#15f9f1f45d9d2cb2187ca532f38286c326f123bc"
+  integrity sha512-rN0KXbzO4moh2932c2wH6xWt7OCHTtMg4z75gXqcXMD4y7pV9eZ6X90USO7amT63YxOQdWlmB7Ce7O/iy2sJtQ==
   dependencies:
     axios "^0.27.2"
     express "^4.18.1"
     express-session "^1.17.3"
     siwe "^2.1.2"
 
-"@spruceid/ssx-gnosis-extension@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@spruceid/ssx-gnosis-extension/-/ssx-gnosis-extension-1.1.3.tgz#5f075f674be3ae4e2adb8b36c8f3763e5e6f5029"
-  integrity sha512-wbxv1B2PdX0LIK3eZLmTndwIxUEEm9RV77qO8h6mh1ifmqaccTv/fWOdFC2Ao503Cp+EYFSmwldrE/0fGQdw8Q==
+"@spruceid/ssx-gnosis-extension@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@spruceid/ssx-gnosis-extension/-/ssx-gnosis-extension-1.1.5.tgz#19a122ba4d2bb06095d8218d7af0f7bd5fd62ec0"
+  integrity sha512-FKPXZBBLk4/sPOD4YooGdAPx8+ghg3047aYWjA51M2mGpplZ7maiiS9BHPCergPX53gx2ZAzXaLjOKG21mXdtg==
   dependencies:
-    "@spruceid/ssx-core" "1.1.1"
+    "@spruceid/ssx-core" "1.2.0"
 
-"@spruceid/ssx-server-middleware@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spruceid/ssx-server-middleware/-/ssx-server-middleware-1.0.1.tgz#6f6e4a9925ac1a13a6fed8909885e9977d2b3236"
-  integrity sha512-7EM+cn25Xn94TPn4eaNRqqNGqavc9EjksSECLiTmuqy+lrtXa/OSflBK+ySskkpYlPoG6sVx8gLo/LBUvaJpLg==
+"@spruceid/ssx-server-middleware@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@spruceid/ssx-server-middleware/-/ssx-server-middleware-1.1.0.tgz#6aa799a4ad937ef92af743ac7fd88f3bd440972a"
+  integrity sha512-UpoYpTTRGHq+rbLHIJnGl+d+wU9GemSno+e0rXjD6BLenKg6ijyXz+4lqyCMGzoTdLnrSlXYl6Y4cbJLmORbnA==
   dependencies:
-    "@spruceid/ssx-core" "1.1.1"
-    "@spruceid/ssx-gnosis-extension" "1.1.3"
+    "@spruceid/ssx-core" "1.2.0"
+    "@spruceid/ssx-gnosis-extension" "1.1.5"
     body-parser "^1.20.0"
     cookie-parser "^1.4.6"
     cors "^2.8.5"
@@ -535,13 +535,13 @@
     express-session "^1.17.3"
 
 "@spruceid/ssx-server@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@spruceid/ssx-server/-/ssx-server-1.2.1.tgz#de6ac06587a139836b890e1c454a8b2153775744"
-  integrity sha512-yClXWC3XMxpiIQrjz/zisdq6kp37r+ZmzCNvyTcbehzARTAjNaA6L5q5duGX5xx4oTKEFBGrNg/8GzoqYSdZVg==
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@spruceid/ssx-server/-/ssx-server-1.2.3.tgz#297bca12aa989003b0634cd904ecb3b2c5c17323"
+  integrity sha512-UbpZ4hDe8WgrrtyQ7y41n2eAzh4b1WD3vxOwRo2xcUwM3nRO6wSwk6B/v/0A4TtDVGe6Zr7pcWHLCUdTKb7Pkw==
   dependencies:
-    "@spruceid/ssx-core" "1.1.1"
-    "@spruceid/ssx-gnosis-extension" "1.1.3"
-    "@spruceid/ssx-server-middleware" "1.0.1"
+    "@spruceid/ssx-core" "1.2.0"
+    "@spruceid/ssx-gnosis-extension" "1.1.5"
+    "@spruceid/ssx-server-middleware" "1.1.0"
     axios "^0.27.2"
     body-parser "^1.20.0"
     cookie-parser "^1.4.6"
@@ -1056,7 +1056,7 @@ bn.js@^5.2.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
-body-parser@1.20.1, body-parser@^1.20.0:
+body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
   integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
@@ -1071,6 +1071,24 @@ body-parser@1.20.1, body-parser@^1.20.0:
     on-finished "2.4.1"
     qs "6.11.0"
     raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
+body-parser@^1.20.0:
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
+  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.5"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.11.0"
+    raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
 
@@ -1261,6 +1279,11 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+
+content-type@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 cookie-parser@^1.4.6:
   version "1.4.6"
@@ -1994,9 +2017,9 @@ minimatch@^3.1.2:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
-  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mri@^1.1.0:
   version "1.2.0"
@@ -2022,6 +2045,11 @@ multiformats@^11.0.0, multiformats@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-11.0.1.tgz#ba58c3f69f032ab67dab4b48cc70f01ac2ca07fe"
   integrity sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==
+
+multiformats@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-11.0.2.tgz#b14735efc42cd8581e73895e66bebb9752151b60"
+  integrity sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -2278,6 +2306,16 @@ raw-body@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
   integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
+  integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
   dependencies:
     bytes "3.1.2"
     http-errors "2.0.0"


### PR DESCRIPTION
Removes SSX endpoints and just submits a SIWE message to delegation endpoints.

Also adds a new test delegation endpoint for claim referrals.